### PR TITLE
Bug removal in resolve

### DIFF
--- a/dns/src/resolver/Main.mo
+++ b/dns/src/resolver/Main.mo
@@ -32,12 +32,12 @@ actor {
         var server = Principal.fromActor(Root);
         var counter = List.size<Text>(parsedDomain);
         while (counter > 0) {
-          server := switch (List.last<Text>(parsedDomain)) {
+          server := switch (List.pop<Text>(parsedDomain).0) {
             case (null) { return #err(#addressNotFound); };
             case (?subdomain) { return await ask(subdomain, server); };
           };
           counter -= 1;
-          parsedDomain := List.drop<Text>(parsedDomain, counter);
+          parsedDomain := List.pop<Text>(parsedDomain).1;
         };
         cache.put(domain, server);
 


### PR DESCRIPTION
As `parseDomain` pushes the domain from left to right onto the list, we would end up with this list for the domain `subdomain.dfinity.com` (if it would have been implemented correctly, the way it's implemented now the `com` is missing):
```
                                           HEAD
                                             +
                                             |
                                             |
+---------+   +---------+  +--------+   +----v---+
| null    +--->subdomain+-->dfinity +--->com     |
|         |   |         |  |        |   |        |
+---------+   +---------+  +--------+   +--------+
```
In the previous code with [`List.last<Text>(parsedDomain)`](https://github.com/dfinity/motoko-base/blob/0ad167b3f08d7d946b3c6d3d8695fcd6d0308f75/src/List.mo#L29) we would assign `?subdomain` to `subdomain` inside the first iteration of the while-loop. We would then ask Root-`server` for `subdomain`. Instead we should ask root for `com` which is the head of the list. 
Additionally we would have then called [`List.drop<Text>(parsedDomain, counter)`](https://github.com/dfinity/motoko-base/blob/0ad167b3f08d7d946b3c6d3d8695fcd6d0308f75/src/List.mo#L179) which would have dropped the first 2 elements in our list, leaving us with nothing but
```
                HEAD
                  +
                  |
                  |
                  v
+---------+   +---+-----+
| null    +--->subdomain|
|         |   |         |
+---------+   +---------+
```
The proposed changes should fix this.