### PR TITLE
Bug removal in split

### DIFF
--- a/dns/src/resolver/Parsing.mo
+++ b/dns/src/resolver/Parsing.mo
@@ -19,7 +19,7 @@ module {
         string #= cc;
       }
     };
-    list
+    return List.push<Text>(string, list);
   };
 
 };


### PR DESCRIPTION
The part of the URL after the last delimiter was missing in the previous implementation, e.g. `subdomain.dfinity.org` would have been split up into `[subdomain, dfinity]' (growing from left to right).